### PR TITLE
Advanced Search: Only administrators and editors can search for generalN...

### DIFF
--- a/apps/qubit/modules/search/templates/_searchFields.php
+++ b/apps/qubit/modules/search/templates/_searchFields.php
@@ -36,7 +36,9 @@
               <option value="identifier"<?php echo $item['field'] == 'identifier' ? ' selected="selected"' : '' ?>><?php echo __('Identifier') ?></option>
               <option value="referenceCode"<?php echo $item['field'] == 'referenceCode' ? ' selected="selected"' : '' ?>><?php echo __('Reference code') ?></option>
               <?php /* Bernhard Search Note*/ ?>
-              <option value="note"<?php echo $item['field'] == 'note' ? 'selected="selected"' : '' ?>><?php echo __('General note(s)') ?></option>
+              <?php if ($sf_user->hasCredential(array('administrator', 'editor'), false)): ?>
++                <?php echo '<option value="note"' ?><?php echo $item['field'] == 'note' ? ' selected="selected"' : '' ?><?php echo '>' ?><?php echo __('General note(s)') ?><?php echo '</option>' ?>
++              <?php endif; ?>
             </select>
           </div>
         </div>
@@ -79,8 +81,9 @@
           <option value="identifier"><?php echo __('Identifier') ?></option>
           <option value="referenceCode"><?php echo __('Reference code') ?></option>
           <?php /* Bernhard Search Note */ ?>
-          <option value="note"><?php echo __('General note(s)') ?></option>
-
+          <?php if ($sf_user->hasCredential(array('administrator', 'editor'), false)): ?>
++            <?php echo '<option value="note">' ?><?php echo __('General note(s)') ?><?php echo '</option>' ?>
++         <?php endif; ?>
         </select>
       </div>
     </div>

--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -210,6 +210,13 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
     return $this->hasGroup(QubitAclGroup::ADMINISTRATOR_ID);
   }
 
+  // Bernhard
+  public function isEditor()
+  {
+    return $this->hasGroup(QubitAclGroup::EDITOR_ID);
+  }
+  // /Bernhard
+
   public function isAuthenticated()
   {
     if (sfConfig::get('app_read_only', false))


### PR DESCRIPTION
...otes. The composition of Elastic Search search fields is changed, so that generalNotes are excluded from search results for authenticated and unauthenticated users alike.
